### PR TITLE
Correct line endings in FEAT response

### DIFF
--- a/src/ftp.c
+++ b/src/ftp.c
@@ -228,7 +228,7 @@ static int32_t ftp_MODE(client_t *client, char *rest) {
 }
 
 static int32_t ftp_FEAT(client_t *client, char *rest) {
-    return write_reply(client, 211, "Features:\n UTF8\n211 End");
+    return write_reply(client, 211, "Features:\r\n UTF8\r\n211 End");
 }
 
 static int32_t ftp_OPTS(client_t *client, char *rest) {


### PR DESCRIPTION
Sorry about the double PR. Per the FTP spec, the `FEAT` response should use `CRLF` (`\r\n`), not just `LF` (`\n`) to delineate each line. Most clients don't care, but some do--probably most notably AndFTP on Android, which will time out the connection after waiting to receive a carriage return that never arrives.